### PR TITLE
hadle exceptions while loading the n-grams

### DIFF
--- a/src/main/java/typeahead/UIMain.kt
+++ b/src/main/java/typeahead/UIMain.kt
@@ -51,6 +51,8 @@ class App : Application() {
             load()
         } successUi {
             guard.close()
+        } fail {
+            throw RuntimeException(it)
         }
 
         stage.scene = Scene(vbox)


### PR DESCRIPTION
If you download the n-gram list and and try to load it as it is in OSX (and possibly other systems) then an MalformedInputException is thrown and silently consumed by the async block.

Just to spare others of figuring this out by themselves.
